### PR TITLE
Move marshal-configs to dir | bump nvdla-sw

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Until this is updated in the NVDLA driver code (when it is eventually bumped to 
 
 # To build the test workloads
 
- 1. Build the Linux kernel, UMD, KMD, and images: ``./marshal -v build $NVDLA_WORKLOAD/<workload>.json``.
+ 1. Build the Linux kernel, UMD, KMD, and images: ``./marshal -v build $NVDLA_WORKLOAD/marshal-configs/<workload>.json``.
  2. Then you can continue with the rest of the FireMarshal commands.

--- a/marshal-configs/nvdla-base.json
+++ b/marshal-configs/nvdla-base.json
@@ -1,6 +1,7 @@
 {
   "name" : "nvdla-base",
   "base" : "br-base.json",
+  "workdir" : "../nvdla-base",
   "host-init" : "build-umd.sh",
   "post-bin" : "build-kmd.sh",
   "linux-config" : "nvdla-kfrag",

--- a/marshal-configs/nvdla-large-regression.json
+++ b/marshal-configs/nvdla-large-regression.json
@@ -1,7 +1,7 @@
 {
   "name" : "nvdla-large-regression",
   "base" : "nvdla-base.json",
-  "workdir" : "nvdla-base",
+  "workdir" : "../nvdla-base",
   "overlay" : "overlay",
   "run" : "./run-nvdla-large-regression.sh",
   "mem" : "4GiB"

--- a/marshal-configs/nvdla-large-resnet50.json
+++ b/marshal-configs/nvdla-large-resnet50.json
@@ -1,7 +1,7 @@
 {
   "name" : "nvdla-large-resnet50",
   "base" : "nvdla-base.json",
-  "workdir" : "nvdla-base",
+  "workdir" : "../nvdla-base",
   "run" : "./run-nvdla.sh resnet50_large.nvdla dog.jpg",
   "files" : [
     ["../models/imagenet/resnet50_large.nvdla", "/root/"],

--- a/marshal-configs/nvdla-small-regression.json
+++ b/marshal-configs/nvdla-small-regression.json
@@ -1,7 +1,7 @@
 {
   "name" : "nvdla-small-regression",
   "base" : "nvdla-base.json",
-  "workdir" : "nvdla-base",
+  "workdir" : "../nvdla-base",
   "overlay" : "overlay",
   "run" : "./run-nvdla-small-regression.sh",
   "mem" : "4GiB"

--- a/marshal-configs/nvdla-small-resnet50.json
+++ b/marshal-configs/nvdla-small-resnet50.json
@@ -1,7 +1,7 @@
 {
   "name" : "nvdla-small-resnet50",
   "base" : "nvdla-base.json",
-  "workdir" : "nvdla-base",
+  "workdir" : "../nvdla-base",
   "run" : "./run-nvdla.sh resnet50_small.nvdla dog.jpg",
   "files" : [
     ["../models/imagenet/resnet50_small.nvdla", "/root/"],


### PR DESCRIPTION
Minor directory cleanup as well as bumping the NVDLA SW repo for speedup and bugfixes. This makes this workload similar to other CY workloads.